### PR TITLE
Fix .git-status padding for empty repos

### DIFF
--- a/styles/status-bar.less
+++ b/styles/status-bar.less
@@ -62,7 +62,6 @@ status-bar .git-branch.inline-block {
 
 status-bar .git-status.inline-block {
   margin-left: 0;
-  padding-left: 0;
   padding-right: @status-bar-spacing;
 }
 


### PR DESCRIPTION
The .git-status div looks wrong for empty repos (see attached before/after screenshots).

<img width="397" alt="before" src="https://cloud.githubusercontent.com/assets/512354/11225591/f2ac0832-8d2f-11e5-8aee-5b98950addc4.png">
<img width="416" alt="after" src="https://cloud.githubusercontent.com/assets/512354/11225590/f2abceda-8d2f-11e5-80cd-88faa83283a5.png">
