### PR TITLE
Move left-side border on editor to treeview #30

### DIFF
--- a/styles/atom.less
+++ b/styles/atom.less
@@ -4,13 +4,6 @@ atom-workspace {
   background-color: @app-background-color;
 }
 
-atom-panel.left,
-.tool-panel.left,
-atom-panel.panel-left,
-.tool-panel.panel-left {
-  border-right: none !important;
-}
-
 // Remove visible scrollbars but don't prevent scrolling
 ::-webkit-scrollbar {
   display: none;

--- a/styles/panels.less
+++ b/styles/panels.less
@@ -15,9 +15,9 @@ atom-panel, .tool-panel {
   background-color: @tool-panel-background-color;
   text-shadow: none;
 
-  // &.left, &.panel-left {
-  //   border-right: 1px solid @tool-panel-border-color;
-  // }
+  &.left, &.panel-left {
+    border-right: 1px solid @tab-bar-border-color;
+  }
 
   &.right, &.panel-right {
     border-left: 1px solid @tool-panel-border-color;

--- a/styles/panes.less
+++ b/styles/panes.less
@@ -21,7 +21,3 @@ atom-pane-container {
     &:last-child { border-bottom: none; }
   }
 }
-
-atom-workspace .horizontal .vertical {
-  border-left: 1px solid @tab-bar-border-color;
-}


### PR DESCRIPTION
<table>
  <tr>
    <td style="width: 50%;">
    <p>When sidebar is closed, the theme adds<br> unnecessary border on left side.</p>
    <img src="https://cloud.githubusercontent.com/assets/1812128/12015866/23793888-ad54-11e5-8739-3d0858212ee7.png" alt="">
    </td>
    <td style="width: 50%;">
    <p>Patch will fix it</p>
    <img src="https://cloud.githubusercontent.com/assets/1812128/12015867/25be92b4-ad54-11e5-87b4-abee2954717f.png" alt="">
    </td>
   </tr>
</table>
