### PR TITLE
Improve native tabs

### DIFF
--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -122,7 +122,6 @@
     z-index: 1;
     color: @text-color-highlight;
     background-color: @tab-background-color-active;
-    box-shadow: inset 0 1px rgba(255, 255, 255, 0.15);
 
     &.modified,
     &.modified:hover,


### PR DESCRIPTION
Native tabs does't have inner shadow (see Terminal.app)
![2015-12-28 11-03-09 maxim maxim maxims-macbook-pro](https://cloud.githubusercontent.com/assets/1812128/12015789/a620ac50-ad52-11e5-85dd-91665f3c1198.png)

But the theme has a 1px white line on top of tab.
![2015-12-28 11-04-06 mixins styl - users maxim projects redisca newyear-2016 - atom](https://cloud.githubusercontent.com/assets/1812128/12015806/db52d57e-ad52-11e5-9207-06fa70152a2f.png)

This patch will remove it.
![2015-12-28 11-05-55 mixins styl - users maxim projects redisca newyear-2016 - atom](https://cloud.githubusercontent.com/assets/1812128/12015824/32043c00-ad53-11e5-8d91-9850373791ff.png)
