### PR TITLE
Apply style to popover lists.

### DIFF
--- a/styles/lists.less
+++ b/styles/lists.less
@@ -104,6 +104,8 @@ autocomplete-suggestion-list.select-list.popover-list .suggestion-description {
 .select-list.popover-list {
   box-shadow: 0 5px 20px rgba(0, 0, 0, 0.3);
   padding: @component-padding/2;
+  background-color: @base-background-color;
+  border-radius: 0 0 @border-radius--base @border-radius--base;
 
   atom-text-editor {
     margin-bottom: @component-padding/2;


### PR DESCRIPTION
Fixes the issue with spellcheck popover list which has a transparent background, and no border radius.

**Before:**
![screen shot 2015-12-28 at 2 43 25 pm](https://cloud.githubusercontent.com/assets/1903876/12025155/632c4ce6-ad71-11e5-987d-5581e5f1350f.png)

**After:**
![screen shot 2016-01-06 at 11 20 58 am](https://cloud.githubusercontent.com/assets/1903876/12149156/c502f210-b467-11e5-8fb8-3ae4d32d9d6d.png)
