### PR TITLE
Minor improvements on tabs

### DIFF
--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -14,6 +14,11 @@
   border-bottom: 1px solid @tab-bar-border-color;
   z-index: 1;
 
+  .is-blurred & {
+    border-bottom-color: lighten(@tab-bar-border-color, 27%);
+    background: lighten(@tab-bar-background-color, 19%)
+  }
+
   // Adjust icon sizes to text
   .icon:before {
     font-size: 14px;
@@ -31,13 +36,16 @@
     margin: 0;
     max-width: 100%;
     flex-grow: 1;
-    transition: background-color @transition--default;
+
+    .is-blurred & {
+      border-right-color: lighten(@tab-bar-border-color, 27%);
+    }
 
     &.active {
       flex: 1; // don't change tab size when selected
     }
 
-    &:hover {
+    &:not(.active):hover {
       background-color: @tab-background-color-hover;
     }
 
@@ -122,7 +130,10 @@
     z-index: 1;
     color: @text-color-highlight;
     background-color: @tab-background-color-active;
-    box-shadow: inset 0 1px rgba(255, 255, 255, 0.15);
+
+    .is-blurred & {
+      background: lighten(@tab-background-color-active, 16%);
+    }
 
     &.modified,
     &.modified:hover,
@@ -173,7 +184,7 @@
 
 // Change the modified icon
 .tab-bar .tab.modified:not(:hover) .close-icon {
-  border: none; 
+  border: none;
   background-color: @text-color;
 }
 

--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -76,12 +76,12 @@
 
 @btn-base-color: #f4f4f4;
 
-@tab-bar-background-color: #b3b1b3;
+@tab-bar-background-color: #C2C0C2;
 @tab-bar-border-color: #979597;
 @tab-bar-border-color-transparent: rgba(0, 0, 0, 0.3);
 @tab-background-color: #b3b1b3;
 @tab-background-color-active: #CFCDCF;
-@tab-background-color-hover: #AAA9AA;
+@tab-background-color-hover: #B4B3B4;
 @tab-border-color: @tab-bar-border-color;
 @tab-text-color: @text-color-highlight;
 
@@ -100,7 +100,7 @@
 @ui-site-color-4: #db2ff4; // purple
 @ui-site-color-5: #f5e11d; // yellow
 
-@background-close-button: rgba(0, 0, 0, 0.13);
+@background-close-button: #A9A8A9;
 @background-close-button-hover: rgba(0, 0, 0, 0.18);
 
 


### PR DESCRIPTION
I've applied a few small changes to the way how tabs look to make them look much more like the ones on all other native windows in El Capitan. All new colours are picked directly from the OS' UI.
- They now look much lighter if the window isn't being used
- Removed transition between normal and hover state
- Colours adjusted

If you want to see more, take a look at [this](http://d.pr/v/1hzZm) and compare it to the current look of the theme.
