### PR TITLE
Remove z-index from modals

### DIFF
--- a/styles/overlays.less
+++ b/styles/overlays.less
@@ -68,7 +68,6 @@ atom-panel.modal,
 }
 
 atom-panel.modal {
-  z-index: 5;
   top: 20% !important;
   border-top-right-radius: @border-radius--base !important;
   border-top-left-radius: @border-radius--base !important;


### PR DESCRIPTION
5 is a really low number whereas the default styling comes with 9999.
5 makes it much more likely that some other plugins will compete and
cause layering problems.
