### PR TITLE
Show full path/filename in the rename modal

### DIFF
--- a/styles/input-fields.less
+++ b/styles/input-fields.less
@@ -7,7 +7,8 @@ atom-panel atom-text-editor[mini],
   box-shadow: none;
   border-color: @input-border-color;
   border-radius: @border-radius--base;
-  padding-left: 8px;
+  padding: 0 8px;
+  max-height: 100%;
   background: @text-color-selected;
   transition: box-shadow @transition--default;
 


### PR DESCRIPTION
If you want to rename a really long path/filename, the mini-editor in the rename-modal cuts up the text, when its longer then the editor itself. There is also no scrollbar visible, so its not clear, that i can scroll vertical to see my full path/filename. 

Better: when the path/filename gets longer, the mini-editor also gets bigger.

Before:
![native-ui-before](https://cloud.githubusercontent.com/assets/8714775/13904432/ce020694-eea0-11e5-8545-efee97bccda7.gif)

After:

![native-ui-after](https://cloud.githubusercontent.com/assets/8714775/13904436/f27ce2a0-eea0-11e5-8210-23a81ec2fa34.gif)
