### PR TITLE
Hide tab bar on startup

### DIFF
--- a/styles/panes.less
+++ b/styles/panes.less
@@ -21,3 +21,7 @@ atom-pane-container {
     &:last-child { border-bottom: none; }
   }
 }
+
+atom-panel-container.left:empty + atom-workspace-axis .tab-bar {
+  display: none;
+}


### PR DESCRIPTION
This PR mimics the behaviour of all native windows and only makes the tab bar show up if multiple files are open (related to https://github.com/fv0/native-ui/issues/47). This solution definitely isn't perfect yet, but it's a great start for implementing this feature, if you ask me.
## How it looks on startup:

![screen shot 2016-05-08 at 16 15 36](https://cloud.githubusercontent.com/assets/6170607/15098256/da2ed1d6-1538-11e6-8ff2-27f6ce40369b.png)
## How it looks with open files:

![screen shot 2016-05-08 at 16 15 46](https://cloud.githubusercontent.com/assets/6170607/15098257/e5ed466a-1538-11e6-86e5-84624e8c615a.png)
