### PR TITLE
hide the scrollbar when scrolling through tabs

### DIFF
--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -30,6 +30,10 @@
   &:empty {
     display: none;
   }
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 } // tab-bar
 
 .tab-bar .tab {


### PR DESCRIPTION
This is super annoying especially when trying to close multiple tabs in a row.