### PR TITLE
feat(tree-view): add focus color

### DIFF
--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -34,7 +34,11 @@
 .list-group .selected:before,
 .list-tree .selected:before {
 	height: @height__list-item;
-	background: @tree-view-background-color-highlight;
+	background: @tree-view-background-color--blurred;
+
+	.tree-view:focus & {
+		background: @tree-view-background-color--active;
+	}
 }
 
 // Modified file

--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -95,7 +95,8 @@
 
 @tree-view-background-color          : transparent;
 @tree-view-border-color              : @tab-bar-border-color-transparent;
-@tree-view-background-color-highlight: linear-gradient(to right, rgba(0,0,0,0.18), rgba(0,0,0, 0.15), rgba(0,0,0, 0.22));
+@tree-view-background-color--active  : linear-gradient(to right, rgba(0,0,0,0.18), rgba(0,0,0, 0.15), rgba(0,0,0, 0.22));
+@tree-view-background-color--blurred : linear-gradient(to right, rgba(0,0,0,0.08), rgba(0,0,0, 0.05), rgba(0,0,0, 0.12));
 
 @ui-site-color-1                     : @background-color-success; // green
 @ui-site-color-2                     : @background-color-info; // blue


### PR DESCRIPTION
Change the color of the selected tree-view item to differentiate which pane one is currently
focused on.

![native-tree-view-focus](https://user-images.githubusercontent.com/1423566/34529634-90630ca4-f0a4-11e7-8c9c-3aa7e929aaf6.gif)
