### PR TITLE
Fix for issue #94 macOS Mojave transparancy

### DIFF
--- a/styles/atom.less
+++ b/styles/atom.less
@@ -16,7 +16,7 @@ html {
 
   // User settings
   &.native-ui-macTransparency {
-    background: transparent;
+    background: @base-background-color-transparent;
   }
 }
 

--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -43,6 +43,7 @@
 @app-background-color                : hsl(0, 0%, 80%);
 
 @base-background-color               : hsl(0, 0%, 92%);
+@base-background-color-transparent   : rgba(246,246,246, 0.65);
 @base-border-color                   : hsl(0, 0%, 78%);
 @base-border-color-transparent       : hsla(0, 0%, 0%, 0.2);
 


### PR DESCRIPTION
Changes 'transparent' base colour to an off white rgba value.

<img width="1280" alt="screenshot 2018-10-26 at 18 59 47" src="https://user-images.githubusercontent.com/12081900/47584180-68491b00-d951-11e8-94e4-9485d9f93ad6.png">
